### PR TITLE
Synchronize API port

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# Spec Agent
+
+This project provides a FastAPI backend and a Streamlit UI.
+
+## Running locally
+
+Use `run.sh` to launch both services:
+
+```bash
+./run.sh
+```
+
+The FastAPI server listens on port **9000** and the Streamlit UI runs on port **8000**.

--- a/run.sh
+++ b/run.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 # cd to src foler first
 cd src
+# Start the FastAPI backend on port 9000
 python -m spec.api.server &
 streamlit run spec.ui.app --server.port 8000 --server.address 0.0.0.0
 wait -n

--- a/src/spec/api/server.py
+++ b/src/spec/api/server.py
@@ -92,4 +92,11 @@ async def any_err(_, exc: Exception):
 
 if __name__ == "__main__":
     import uvicorn
-    uvicorn.run("spec.api.server:app", host="0.0.0.0", port=9000, reload=True)
+    from spec.config import settings
+
+    uvicorn.run(
+        "spec.api.server:app",
+        host="0.0.0.0",
+        port=settings.port,
+        reload=True,
+    )

--- a/src/spec/config/settings.py
+++ b/src/spec/config/settings.py
@@ -6,7 +6,7 @@ from pydantic_settings import BaseSettings
 
 class Settings(BaseSettings):
     max_token_limit: int = 950000
-    port: int = 9001
+    port: int = 9000
     url: str = f"http://localhost:{port}"
     sleep = 0.03
     authen_file: Path = Path(__file__).parent.parent.parent / 'authen.yaml'


### PR DESCRIPTION
## Summary
- pick a single port for the FastAPI server
- use that port in `settings.py`, `server.py`, and `run.sh`
- document ports in the README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_683e79e8285c8323bad6d7cab5c14934

## Summary by Sourcery

Synchronize the FastAPI server port to a single setting and update configuration, startup scripts, and documentation to use port 9000 consistently

Enhancements:
- Centralize the API port in settings and use it for server startup
- Change the default port from 9001 to 9000 to align with the running server
- Update the run.sh script to launch the backend on the configured port

Documentation:
- Add README instructions for running services locally and document that FastAPI runs on port 9000 and Streamlit on port 8000