### PR TITLE
Add streaming API server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Spec Agent
 
-Spec Agent provides a small collection of LLM powered agents exposed through a FastAPI backend and a Streamlit web UI.  Users authenticate via credentials stored in `authen.yaml` and can chat with agents that retrieve specbook information or analyse BOM data.
+Spec Agent provides a small collection of LLM powered agents exposed through a FastAPI backend.  Users authenticate via credentials stored in `authen.yaml` and can chat with agents that retrieve specbook information or analyse BOM data.  The previous Streamlit interface has been removed so you can build a custom frontend using the API.
 
 ## Requirements
 
@@ -33,23 +33,14 @@ Create `authen.yaml` in the project root containing user login information. A he
 
 ## Running the application
 
-The easiest way to run both the API and the UI locally is with the provided script:
-
-```bash
-./run.sh
-```
-
-This launches the FastAPI backend (`python -m spec.api.server`) and the Streamlit UI on port `8000`. With the default settings the backend listens on `http://localhost:9000`.
-
-You may also start the services manually:
+Start the API server with `uvicorn`:
 
 ```bash
 cd src
-python -m spec.api.server               # backend on port 9000
-streamlit run spec.ui.app --server.port 8000 --server.address 0.0.0.0
+uvicorn spec.api.server:app --reload --port 9000
 ```
 
-Once running, navigate to `http://localhost:8000` and log in with one of the accounts defined in `authen.yaml` to start chatting with the agents.
+The API exposes a single `/chat` endpoint that streams assistant responses as Server-Sent Events. Build any frontend of your choice that consumes this endpoint.
 
 ## Deploying to Azure AKS
 

--- a/src/spec/api/server.py
+++ b/src/spec/api/server.py
@@ -1,0 +1,37 @@
+from typing import List
+import asyncio
+
+from fastapi import FastAPI
+from fastapi.responses import StreamingResponse
+from pydantic import BaseModel
+
+from agents import Runner, TResponseInputItem
+from spec.agents import triage_agent
+from spec.models import ContextHook, LiveStream
+
+app = FastAPI()
+
+class ChatRequest(BaseModel):
+    messages: List[TResponseInputItem]
+
+@app.post("/chat")
+async def chat(req: ChatRequest):
+    buffer = LiveStream()
+    hook = ContextHook(buffer)
+    result = Runner.run_streamed(triage_agent, input=req.messages, context=hook)
+
+    async def consume_events():
+        async for ev in result.stream_events():
+            if ev.type == "raw_response_event" and hasattr(ev.data, "delta"):
+                hook.write(ev.data.delta)
+        hook.finish()
+
+    task = asyncio.create_task(consume_events())
+
+    async def event_stream():
+        async for chunk in buffer.stream():
+            yield f"data: {chunk}\n\n"
+        await task
+        yield "data: [DONE]\n\n"
+
+    return StreamingResponse(event_stream(), media_type="text/event-stream")


### PR DESCRIPTION
## Summary
- provide a small FastAPI server
- document running the API instead of Streamlit
- improve streaming classes to work with the API

## Testing
- `pytest`
- `PYTHONPATH=src python test.py` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6843e7da10948323a9c187b07c736a2e

## Summary by Sourcery

Introduce a streaming FastAPI server for agent chat, refactor in-memory streaming classes for asynchronous operation, and update documentation to guide users in running the API instead of the Streamlit interface.

New Features:
- Add FastAPI-based `/chat` endpoint that streams agent responses as Server-Sent Events

Enhancements:
- Refactor LiveStream and ContextHook to use asyncio.Queue with async iteration support

Documentation:
- Remove Streamlit UI instructions from README and update to use uvicorn and the new API server